### PR TITLE
fix: :bug: add REDIS_USERNAME support for Redis ACL authentication

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,16 +70,18 @@ class TestRedisSettings:
         assert settings.db == 1
 
     def test_default_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that RedisSettings has sensible defaults."""
-        # Clear any existing REDIS_ env vars
+        """Test that RedisSettings has sensible defaults for optional fields."""
+        # Clear any existing REDIS_ env vars except HOST (which is required)
         for key in list(os.environ.keys()):
             if key.startswith("REDIS_"):
                 monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("REDIS_HOST", "localhost")
 
         settings = RedisSettings()
 
         assert settings.host == "localhost"
         assert settings.port == 6379  # noqa: PLR2004
+        assert settings.username is None
         assert settings.password is None
         assert settings.db == 0
 
@@ -96,15 +98,28 @@ class TestRedisSettings:
         assert settings.url == "redis://redis-server:6380/2"
 
     def test_url_property_with_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test URL property generates correct URL with password."""
+        """Test URL property generates correct URL with password only."""
         monkeypatch.setenv("REDIS_HOST", "redis-server")
         monkeypatch.setenv("REDIS_PORT", "6380")
+        monkeypatch.setenv("REDIS_PASSWORD", "secret")
+        monkeypatch.setenv("REDIS_DB", "2")
+        monkeypatch.delenv("REDIS_USERNAME", raising=False)
+
+        settings = RedisSettings()
+
+        assert settings.url == "redis://:secret@redis-server:6380/2"
+
+    def test_url_property_with_username_and_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test URL property generates correct URL with username and password (ACL auth)."""
+        monkeypatch.setenv("REDIS_HOST", "redis-server")
+        monkeypatch.setenv("REDIS_PORT", "6380")
+        monkeypatch.setenv("REDIS_USERNAME", "default")
         monkeypatch.setenv("REDIS_PASSWORD", "secret")
         monkeypatch.setenv("REDIS_DB", "2")
 
         settings = RedisSettings()
 
-        assert settings.url == "redis://:secret@redis-server:6380/2"
+        assert settings.url == "redis://default:secret@redis-server:6380/2"
 
 
 class TestSkillConfig:
@@ -116,6 +131,8 @@ class TestSkillConfig:
         monkeypatch.setenv("SPOTIFY_CLIENT_ID", "test_client_id")
         monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "test_client_secret")
         monkeypatch.setenv("SPOTIFY_REDIRECT_URI", "http://localhost:8080/callback")
+        # Set required Redis env vars
+        monkeypatch.setenv("REDIS_HOST", "localhost")
 
         data_directory = pathlib.Path(__file__).parent / "data" / "config.yaml"
         with data_directory.open("r") as file:
@@ -138,6 +155,8 @@ class TestSkillConfig:
         monkeypatch.setenv("SPOTIFY_CLIENT_ID", "test_client_id")
         monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "test_client_secret")
         monkeypatch.setenv("SPOTIFY_REDIRECT_URI", "http://localhost:8080/callback")
+        # Set required Redis env vars
+        monkeypatch.setenv("REDIS_HOST", "localhost")
 
         invalid_yaml = """
 mqtt_server_host: "test_host"

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-spotify-skill"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Redis deployments using ACL authentication require both username and
password. Added username field to RedisSettings and updated URL
property to include username when both username and password are set.
REDIS_HOST is now a required field with no default value.